### PR TITLE
Update to use gas-preprocessor in libx264 tools folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a shell script to build x264 for iOS apps.
 
 Tested with:
 
-* x264-snapshot-20140914-2245
+* x264-snapshot-20160814-2245-stable.tar.bz2
 * Xcode 7
 
 ## Requirements
@@ -12,6 +12,8 @@ Tested with:
 * https://github.com/libav/gas-preprocessor
 
 ## Usage
+
+* Untar the source code into a folder named x264
 
 * To build everything:
 
@@ -28,3 +30,6 @@ Tested with:
 * To build fat library from separately built thin libraries:
 
         ./build-x264.sh lipo
+
+* Library and Header Files are in
+	./x264-iOS

--- a/build-x264.sh
+++ b/build-x264.sh
@@ -12,9 +12,6 @@ SCRATCH="scratch-x264"
 # must be an absolute path
 THIN=`pwd`/"thin-x264"
 
-# the one included in x264 does not work; specify full path to working one
-GAS_PREPROCESSOR=/usr/local/bin/gas-preprocessor.pl
-
 COMPILE="y"
 LIPO="y"
 
@@ -75,7 +72,7 @@ then
 		CC="xcrun -sdk $XCRUN_SDK clang"
 		if [ $PLATFORM = "iPhoneOS" ]
 		then
-		    export AS="gas-preprocessor.pl $XARCH -- $CC"
+		    export AS="$CWD/$SOURCE/tools/gas-preprocessor.pl $XARCH -- $CC"
 		else
 		    export -n AS
 		fi
@@ -89,9 +86,6 @@ then
 		    --extra-asflags="$ASFLAGS" \
 		    --extra-ldflags="$LDFLAGS" \
 		    --prefix="$THIN/$ARCH" || exit 1
-
-		mkdir extras
-		ln -s $GAS_PREPROCESSOR extras
 
 		make -j3 install || exit 1
 		cd $CWD


### PR DESCRIPTION
Had a look at the build script and made a few small changes

1) There is a gas-preprocessor in the x264 source. It was in 'extras' folder and then moved to 'tools'.
I edited the build script to use the built in gas-preprocessor which is in $CWD/$SOURCE/tools/ and it works fine with all the ARCHes

2) I've made a small Xcode project that links in the library and initialises it and writes some values to the console. It works on my Mac Book Pro (in the emulator) and on an Phone 5 so it all looks good.

Will test with other Apple devices shortly and then test in a real video conferencing project that I'm working on.

Thanks
Roger
